### PR TITLE
Laravel 5.x compatibility fixes

### DIFF
--- a/src/Concerns/HasAttributesCompatibility.php
+++ b/src/Concerns/HasAttributesCompatibility.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Matchory\Elasticsearch\Concerns;
+
+use Illuminate\Support\Arr;
+use Matchory\Elasticsearch\Interfaces\CastableInterface;
+use Matchory\Elasticsearch\Interfaces\CastsInboundAttributesInterface;
+use Matchory\Elasticsearch\Exceptions\InvalidCastException;
+
+
+/**
+ * Add some compatibility properties and methods for old Laravel versions
+ *
+ * @package Matchory\Elasticsearch\Concerns
+ * @see     \Illuminate\Database\Eloquent\Concerns\HasAttributes
+ */
+trait HasAttributesCompatibility
+{
+    /**
+     * The attributes that have been cast using custom classes.
+     *
+     * @var array
+     */
+    protected $classCastCache = [];
+
+    /**
+     * The built-in, primitive cast types supported by Eloquent.
+     *
+     * @var string[]
+     */
+    protected static $primitiveCastTypes = [
+        'array',
+        'bool',
+        'boolean',
+        'collection',
+        'custom_datetime',
+        'date',
+        'datetime',
+        'decimal',
+        'double',
+        'encrypted',
+        'encrypted:array',
+        'encrypted:collection',
+        'encrypted:json',
+        'encrypted:object',
+        'float',
+        'int',
+        'integer',
+        'json',
+        'object',
+        'real',
+        'string',
+        'timestamp',
+    ];
+
+
+    /**
+     * Merge new casts with existing casts on the model.
+     *
+     * @param  array  $casts
+     * @return $this
+     */
+    public function mergeCasts($casts)
+    {
+        $this->casts = array_merge($this->casts, $casts);
+
+        return $this;
+    }
+
+    /**
+     * Get the attributes that should be converted to dates.
+     * While usesTimestamps() always return false, use short version of HasAttributes::getDates(),
+     * because there is no check of usesTimestamps() in Laravel 5.x version
+     *
+     * @return array
+     */
+    public function getDates()
+    {
+        return $this->dates;
+    }
+
+    /**
+     * Determine if the new and old values for a given key are equivalent.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function originalIsEquivalent($key)
+    {
+        if (! array_key_exists($key, $this->original)) {
+            return false;
+        }
+
+        $attribute = Arr::get($this->attributes, $key);
+        $original = Arr::get($this->original, $key);
+
+        if ($attribute === $original) {
+            return true;
+        } elseif (is_null($attribute)) {
+            return false;
+        } elseif ($this->isDateAttribute($key)) {
+            return $this->fromDateTime($attribute) ===
+                $this->fromDateTime($original);
+        } elseif ($this->hasCast($key, ['object', 'collection'])) {
+            return $this->castAttribute($key, $attribute) ==
+                $this->castAttribute($key, $original);
+        } elseif ($this->hasCast($key, ['real', 'float', 'double'])) {
+            if (($attribute === null && $original !== null) || ($attribute !== null && $original === null)) {
+                return false;
+            }
+
+            return abs($this->castAttribute($key, $attribute) - $this->castAttribute($key, $original)) < PHP_FLOAT_EPSILON * 4;
+        } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
+            return $this->castAttribute($key, $attribute) ===
+                $this->castAttribute($key, $original);
+        }
+
+        return is_numeric($attribute) && is_numeric($original)
+            && strcmp((string) $attribute, (string) $original) === 0;
+    }
+
+    /**
+     * Determine if the given key is cast using a custom class.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isClassCastable($key)
+    {
+        if (! array_key_exists($key, $this->getCasts())) {
+            return false;
+        }
+
+        $castType = $this->parseCasterClass($this->getCasts()[$key]);
+
+        if (in_array($castType, static::$primitiveCastTypes)) {
+            return false;
+        }
+
+        if (class_exists($castType)) {
+            return true;
+        }
+
+        throw new InvalidCastException($this->getModel(), $key, $castType);
+    }
+
+    /**
+     * Merge the cast class attributes back into the model.
+     *
+     * @return void
+     */
+    protected function mergeAttributesFromClassCasts()
+    {
+        foreach ($this->classCastCache as $key => $value) {
+            $caster = $this->resolveCasterClass($key);
+
+            $this->attributes = array_merge(
+                $this->attributes,
+                $caster instanceof CastsInboundAttributesInterface
+                    ? [$key => $value]
+                    : $this->normalizeCastClassResponse($key, $caster->set($this, $key, $value, $this->attributes))
+            );
+        }
+    }
+
+    /**
+     * Resolve the custom caster class for a given key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    protected function resolveCasterClass($key)
+    {
+        $castType = $this->getCasts()[$key];
+
+        $arguments = [];
+
+        if (is_string($castType) && strpos($castType, ':') !== false) {
+            $segments = explode(':', $castType, 2);
+
+            $castType = $segments[0];
+            $arguments = explode(',', $segments[1]);
+        }
+
+        if (is_subclass_of($castType, CastableInterface::class)) {
+            $castType = $castType::castUsing($arguments);
+        }
+
+        if (is_object($castType)) {
+            return $castType;
+        }
+
+        return new $castType(...$arguments);
+    }
+
+    /**
+     * Parse the given caster class, removing any arguments.
+     *
+     * @param  string  $class
+     * @return string
+     */
+    protected function parseCasterClass($class)
+    {
+        return strpos($class, ':') === false
+            ? $class
+            : explode(':', $class, 2)[0];
+    }
+
+    /**
+     * Normalize the response from a custom class caster.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return array
+     */
+    protected function normalizeCastClassResponse($key, $value)
+    {
+        return is_array($value) ? $value : [$key => $value];
+    }
+
+}
+

--- a/src/Exceptions/InvalidCastException.php
+++ b/src/Exceptions/InvalidCastException.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Matchory\Elasticsearch\Exceptions;
+
+use RuntimeException;
+
+class InvalidCastException extends RuntimeException
+{
+    /**
+     * The name of the affected model.
+     *
+     * @var string
+     */
+    public $model;
+
+    /**
+     * The name of the column.
+     *
+     * @var string
+     */
+    public $column;
+
+    /**
+     * The name of the cast type.
+     *
+     * @var string
+     */
+    public $castType;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  object  $model
+     * @param  string  $column
+     * @param  string  $castType
+     * @return static
+     */
+    public function __construct($model, $column, $castType)
+    {
+        $class = get_class($model);
+
+        parent::__construct("Call to undefined cast [{$castType}] on column [{$column}] in model [{$class}].");
+
+        $this->model = $class;
+        $this->column = $column;
+        $this->castType = $castType;
+    }
+}

--- a/src/Interfaces/CastableInterface.php
+++ b/src/Interfaces/CastableInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Matchory\Elasticsearch\Interfaces;
+
+interface CastableInterface
+{
+    /**
+     * Get the name of the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return mixed
+     */
+    public static function castUsing(array $arguments);
+}

--- a/src/Interfaces/CastsInboundAttributesInterface.php
+++ b/src/Interfaces/CastsInboundAttributesInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Matchory\Elasticsearch\Interfaces;
+
+use Matchory\Elasticsearch\Model;
+
+interface CastsInboundAttributesInterface
+{
+    /**
+     * Transform the attribute to its underlying model values.
+     *
+     * @param  Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, string $key, $value, array $attributes);
+}

--- a/src/Model.php
+++ b/src/Model.php
@@ -15,17 +15,18 @@ use Illuminate\Database\Eloquent\Concerns\GuardsAttributes;
 use Illuminate\Database\Eloquent\Concerns\HasAttributes;
 use Illuminate\Database\Eloquent\Concerns\HasEvents;
 use Illuminate\Database\Eloquent\Concerns\HidesAttributes;
-use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\MassAssignmentException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonException;
 use JsonSerializable;
+use Matchory\Elasticsearch\Concerns\HasAttributesCompatibility;
 use Matchory\Elasticsearch\Concerns\HasGlobalScopes;
 use Matchory\Elasticsearch\Exceptions\DocumentNotFoundException;
 use Matchory\Elasticsearch\Interfaces\ConnectionInterface as Connection;
 use Matchory\Elasticsearch\Interfaces\ConnectionResolverInterface as Resolver;
+use Matchory\Elasticsearch\Exceptions\InvalidCastException;
 
 use function array_key_exists;
 use function array_merge;
@@ -72,6 +73,16 @@ class Model implements Arrayable,
     use HasEvents;
     use HasGlobalScopes;
     use GuardsAttributes;
+    use HasAttributesCompatibility {
+        HasAttributesCompatibility::getDates insteadof HasAttributes;
+        HasAttributesCompatibility::isClassCastable insteadof HasAttributes;
+        HasAttributesCompatibility::mergeAttributesFromClassCasts insteadof HasAttributes;
+        HasAttributesCompatibility::mergeCasts insteadof HasAttributes;
+        HasAttributesCompatibility::normalizeCastClassResponse insteadof HasAttributes;
+        HasAttributesCompatibility::originalIsEquivalent insteadof HasAttributes;
+        HasAttributesCompatibility::parseCasterClass insteadof HasAttributes;
+        HasAttributesCompatibility::resolveCasterClass insteadof HasAttributes;
+    }
 
     protected const FIELD_ID = '_id';
 
@@ -1371,6 +1382,16 @@ class Model implements Arrayable,
             ? $this->transformModelValue($key, $this->resultMetadata[$key])
             : null;
     }
+
+    /**
+     * Get the model instance being queried.
+     * @return $this
+     */
+    public function getModel()
+    {
+        return $this;
+    }
+
 
     /**
      * Perform the actual delete query on this model instance.


### PR DESCRIPTION
Most problems were in HasAttributes trait. I've collected missing methods and properties in HasAttributesCompatibility trait and added some missing Interfaces and Exception. All existing tests are passing now for both Laravel 5.x and 8.x version, but it could be some problems with dates casting for old Laravel versions.