### PR TITLE
Allow to define metadata when creating a new document

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -250,12 +250,17 @@ class Model implements Arrayable,
      * Save a new model and return the instance.
      *
      * @param array $attributes
-     * @param array $metadata
+     * @param string|null $id
      * @return static
      * @psalm-suppress LessSpecificReturnStatement
      */
-    public static function create(array $attributes, array $metadata = []): self
+    public static function create(array $attributes, ?string $id = null): self
     {
+        $metadata = [];
+        if (!is_null($id)) {
+            $metadata['_id'] = $id;
+        }
+
         return tap(
             (new static())->newInstance($attributes, $metadata),
             static function ($instance) {

--- a/src/Model.php
+++ b/src/Model.php
@@ -250,14 +250,14 @@ class Model implements Arrayable,
      * Save a new model and return the instance.
      *
      * @param array $attributes
-     *
+     * @param array $metadata
      * @return static
      * @psalm-suppress LessSpecificReturnStatement
      */
-    public static function create(array $attributes): self
+    public static function create(array $attributes, array $metadata = []): self
     {
         return tap(
-            (new static())->newInstance($attributes),
+            (new static())->newInstance($attributes, $metadata),
             static function ($instance) {
                 $instance->save();
             }


### PR DESCRIPTION
In certain use cases we need to define `_id` when creating a new document.
The `newInstance` method already allows to pass `$metadata` as an optional second parameter.
By adding this optional parameter to the `create` method, we can allow the user to define `_id` as a metadata field.

```
Model::create([
  'name' => 'something',
], [
  '_id' => 'my-id-123'
]
```