### PR TITLE
Changed return type of array_map() in toArray() to mixed

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -167,7 +167,7 @@ class Collection extends BaseCollection
      */
     public function toArray(): array
     {
-        return array_map(static function ($item): array {
+        return array_map(static function ($item): mixed {
             return $item instanceof Arrayable
                 ? $item->toArray()
                 : $item;


### PR DESCRIPTION
When calling `map()` on a `Collection` and calling `toArray()` afterwards, an exception is thrown.
Example:

```
$ids = $executions->map(function (Execution $e) {
    return $e->id;
});

dump($ids);
dump($ids->toArray());
```

```
Matchory\Elasticsearch\Collection^ {#3805
  #total: null
  #maxScore: null
  #duration: null
  #timedOut: null
  #scrollId: null
  #shards: null
  #suggestions: null
  #aggregations: null
  #items: array:1 [
    0 => "heller.biz/bednar.GR23809051973BZ92HK5UI93IS1"
  ]
}
```

```
TypeError: Matchory\Elasticsearch\Collection::Matchory\Elasticsearch\{closure}(): Return value must be of type array, string returned
```

This is caused by the `Collection`'s `toArray()` method expecting an `array` to be returned by `array_map()`.
In this scenario, `array_map()` can return different types, in this case a `string`.

This PR changes the expected return type of `array_map()` to from `array` to `mixed`.