### PR TITLE
Added support for selecting from "fields" instead of "_source"'

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -74,6 +74,8 @@ class Query implements Arrayable, JsonSerializable, Jsonable, IteratorAggregate
 
     protected const FIELD_SOURCE = '_source';
 
+    protected const FIELD_FIELDS = 'fields';
+
     protected const FIELD_TYPE = '_type';
 
     public const GT = self::OPERATOR_GREATER_THAN;
@@ -137,6 +139,8 @@ class Query implements Arrayable, JsonSerializable, Jsonable, IteratorAggregate
     public const SOURCE_EXCLUDES = 'excludes';
 
     public const SOURCE_INCLUDES = 'includes';
+
+    public const GET_DATA_FROM = self::FIELD_FIELDS;
 
     protected static $defaultSource = [
         self::SOURCE_INCLUDES => [],

--- a/src/Query.php
+++ b/src/Query.php
@@ -140,12 +140,12 @@ class Query implements Arrayable, JsonSerializable, Jsonable, IteratorAggregate
 
     public const SOURCE_INCLUDES = 'includes';
 
-    public const GET_DATA_FROM = self::FIELD_FIELDS;
-
     protected static $defaultSource = [
         self::SOURCE_INCLUDES => [],
         self::SOURCE_EXCLUDES => [],
     ];
+
+    public static $getDataFrom = self::FIELD_FIELDS;
 
     /**
      * @var null

--- a/src/Query.php
+++ b/src/Query.php
@@ -140,8 +140,6 @@ class Query implements Arrayable, JsonSerializable, Jsonable, IteratorAggregate
 
     public const SOURCE_INCLUDES = 'includes';
 
-    public const GET_DATA_FROM = self::FIELD_FIELDS;
-
     protected static $defaultSource = [
         self::SOURCE_INCLUDES => [],
         self::SOURCE_EXCLUDES => [],


### PR DESCRIPTION
We can't get fields with type **alias** in **_source** from ES
So we need to pass **fields** parameter in body request instead of **_source**
This fix allows to choose how to receive data
**fields** recommended by ES (as typically better) and set by default